### PR TITLE
Add settings option page to "Settings" menu

### DIFF
--- a/options.php
+++ b/options.php
@@ -88,7 +88,7 @@ function video_embed_privacy_show_options() {
 }
 
 function video_embed_privacy_admin_menu() {
-	add_submenu_page('_doesnt_exist', __('Video Embed Privacy settings', 'video-embed-privacy'), '', 'manage_options', 'video-embed-privacy', 'video_embed_privacy_show_options');
+	add_options_page(__('Video Embed Privacy settings', 'video-embed-privacy'), __('Embed videos and respect privacy', 'video-embed-privacy'), 'manage_options', 'video-embed-privacy', 'video_embed_privacy_show_options');
 }
 
 add_action('admin_init', 'video_embed_privacy_settings_init');

--- a/video-embed-privacy.php
+++ b/video-embed-privacy.php
@@ -146,7 +146,7 @@ function video_embed_privacy_write_settings() {
 
 function video_embed_privacy_add_action_links ( $links ) {
 	$mylinks = array(
-			'<a href="' . admin_url( 'options.php?page=video-embed-privacy' ) . '">' . esc_html__('Settings', 'video-embed-privacy') . '</a>',
+			'<a href="' . admin_url( 'options-general.php?page=video-embed-privacy' ) . '">' . esc_html__('Settings', 'video-embed-privacy') . '</a>',
 	);
 	return array_merge( $links, $mylinks );
 }


### PR DESCRIPTION
As described in #16 a), the settings page of this plugin is currently only accessible via the "Installed Plugins" page, but not via the "Settings" menu. This change registers the settings page also with the "Settings" menu.

Note that this also changes the URL of the settings page. Therefore, the action links also had to be adapted.